### PR TITLE
Add github PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,25 @@
+## What
+
+_Add a link to the Github Project issue_
+
+_Provide a short description about the goal of suggested changes_
+
+## How
+
+_Describe the high level description of the implementation_
+
+### Gotchas
+
+_Any potential issues to keep in mind regarding merging these changes to master? Then mention it and provide a description/solution_
+
+## Screenshots
+
+_If PR changes is related to UI then provide corresponding screenshots/clips_
+
+## Testing
+
+_Provide instructions on how to test PR changes if additional testing outside of the CI is required_
+
+## Deployment
+
+_Any potential issues to keep in mind regarding CD/deployment/data migration related to PR? Then mention it and provide guide/instructions/checklist_


### PR DESCRIPTION
## What

Added Github PR template for easier PR creationg and editing.

## How

`.github/PULL_REQUEST_TEMPLATE.md`

### Gotchas

Won't work on already existing PRs.

## Screenshots

N/A

## Testing

Create a new PR after merging to master.

## Deployment

N/A